### PR TITLE
Update CommentsModel.php

### DIFF
--- a/component/backend/src/Model/CommentsModel.php
+++ b/component/backend/src/Model/CommentsModel.php
@@ -273,7 +273,7 @@ class CommentsModel extends ListModel
 
 		$orderDirn = $this->state->get('list.direction', 'DESC');
 
-		if (is_null($parentId) && strtoupper($orderDirn) === 'DESC')
+		if (!is_null($parentId) && strtoupper($orderDirn) === 'DESC')
 		{
 			$childIDs = array_reverse($childIDs);
 		}


### PR DESCRIPTION
Descending sorting (DESC) of comments does not work because the sorting is reversed when comments have no parent.

Sorting should be reversed only when comments have a parent to put child comments back in chronological order