### PR TITLE
Update CommentsController.php

### DIFF
--- a/component/frontend/src/Controller/CommentsController.php
+++ b/component/frontend/src/Controller/CommentsController.php
@@ -350,7 +350,7 @@ class CommentsController extends AdminCommentsController
 		$defaultLimit = $this->getDefaultListLimit();
 		$start        = $this->app->getUserStateFromRequest('com_engage.comments.limitstart', 'akengage_limitstart', 0);
 		$limit        = $this->app->getUserStateFromRequest('com_engage.comments.limit', 'akengage_limit', $defaultLimit);
-		$ordering     = $this->input->get('akengage_order', 'id');
+		$ordering     = $this->input->get('akengage_order', 'c.id');
 		$orderDir     = strtoupper($this->input->get('akengage_order_Dir', 'DESC') ?: 'DESC');
 		$orderDir     = in_array($orderDir, ['ASC', 'DESC']) ? $orderDir : 'DESC';
 


### PR DESCRIPTION
The id field is ambiguous in the sort because the SQL query on the #__engage_comments table has joins on the #__content and #__categories tables (see the getListQuery method of the administrator/components/com_engage/src/Model/CommentsModel.php file).

This ambiguity does not create a issue, it is just a little improvement