### PR TITLE
Adding transaltions in plg_content_engage.ini (DE)

### DIFF
--- a/plugins/content/engage/language/de-DE/plg_content_engage.ini
+++ b/plugins/content/engage/language/de-DE/plg_content_engage.ini
@@ -1,6 +1,7 @@
 ;; @package   AkeebaEngage
 ;; @copyright Copyright (c)2020-2021 Nicholas K. Dionysopoulos / Akeeba Ltd
 ;; @license   GNU General Public License version 3, or later
+;; German Translation by NetSecond.net (2022/09)
 
 COM_ENGAGE_COMMENTS_ARTICLE_HEADER_N_COMMENTS_0="Keine Kommentare zu “%2$s”"
 COM_ENGAGE_COMMENTS_ARTICLE_HEADER_N_COMMENTS_1="Ein Kommentar zu “%2$s”"
@@ -11,6 +12,9 @@ PLG_CONTENT_ENGAGE_FORM_SUBHEAD="Konfigurieren der Artikelkommentare. Powered by
 
 PLG_CONTENT_ENGAGE_COMMENTS_SHOW_LABEL="Kommentaroberfläche"
 PLG_CONTENT_ENGAGE_COMMENTS_SHOW_DESC="Soll die Kommentaroberfläche angezeigt werden? Wenn Ausblenden gewählt wird, werden alle vorhandenen Kommentare ausgeblendet und neue Kommentare deaktiviert."
+
+PLG_CONTENT_ENGAGE_DEFAULT_PUBLISH_LABEL="Neue Kommentare"
+PLG_CONTENT_ENGAGE_DEFAULT_PUBLISH_DESC="<p>Sollen neu gepostete Kommentare standardmäßig veröffentlicht oder nicht veröffentlicht werden? Im letzteren Fall muss ein Kommentaradministrator sie manuell veröffentlichen. Die Option „Global verwenden“ (Standard) weist Akeeba Engage an, das zu tun, was auf der Seite „Optionen“ der Komponente festgelegt wurde.</p><p><strong>WICHTIG!</strong> Diese Option gilt NICHT für Kommentare, die von Kommentaradministratoren veröffentlicht werden. Diese Kommentare werden immer sofort veröffentlicht. Es wäre unsinnig, den Nutzer, der einen solchen Kommentar postet, aufzufordern, seinen eigenen Kommentar zu moderieren.</p>"
 
 PLG_CONTENT_ENGAGE_COMMENTS_SHOW_FEATURE_LABEL="Zusammenfassung der ausgewählten Anzeige"
 PLG_CONTENT_ENGAGE_COMMENTS_SHOW_FEATURE_DESC="Soll die Anzahl der Kommentare angezeigt werden, die für jeden Artikel in Joomlas Anzeige Ausgewählte Artikel veröffentlicht wurden?"


### PR DESCRIPTION
Adding missing/new transaltions for plg_content_engage.ini in german language: PLG_CONTENT_ENGAGE_DEFAULT_PUBLISH_LABEL
PLG_CONTENT_ENGAGE_DEFAULT_PUBLISH_DESC
