### PR TITLE
Fix deletion of comment with nested comments

### DIFF
--- a/component/backend/src/Model/CommentsModel.php
+++ b/component/backend/src/Model/CommentsModel.php
@@ -630,5 +630,9 @@ class CommentsModel extends ListModel
 		return parent::getStoreId($id);
 	}
 
+	public function clearCache($id = '')
+	{
+		unset($this->cache[$this->getStoreId($id)]);
+	}
 
 }

--- a/component/backend/src/Table/CommentTable.php
+++ b/component/backend/src/Table/CommentTable.php
@@ -137,6 +137,7 @@ class CommentTable extends AbstractTable
 
 		while (true)
 		{
+			$commentsModel->clearCache();
 			$commentsSlice = $commentsModel->getItems();
 
 			if (empty($commentsSlice))


### PR DESCRIPTION
Pull Request to correct an infinite loop.

### Summary of Changes

Joomla! had the very good idea of caching results of `getList()`, and not update it on deleting. This creates an infinite loop when deleting child comments, as we never see the effect of the deletion.
This PR add a `clearCache()` method to the `CommentsModel` to force re-execution of the `getList()` request.

### Testing Instructions

Created two nested comments, delete the root one on Joomla 5.2.0.

Before PR:
* Crash (timeout)

After PR:
* Comments are deleted

### Backwards compatibility
Unknown. Will probably break on Joomla! versions that do not implement `ListModel` cache.

### Documentation Changes Required

None.

### Translation impact
None.

### Technical information
None.